### PR TITLE
v0.1.5: Restoring syntax fix for javascript and added typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ SvelteNova.novaextension/README.md
 SvelteNova.novaextension/CHANGELOG.md
 SvelteNova.novaextension/LICENSE
 SvelteNova.novaextension/Scripts/**/*
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.5
+
+- Fixed missing syntax highlighting for script tags (added by @pierreminik who copied updates from @tommasongr's [vue extension](https://github.com/tommasongr/nova-vue)).
+
 # v0.1.4
 
 - `chmod +x` before try starting server.

--- a/SvelteNova.novaextension/Syntaxes/Svelte.xml
+++ b/SvelteNova.novaextension/Syntaxes/Svelte.xml
@@ -438,46 +438,164 @@
               </subscopes>
             </scope>
             
-            <!-- Style -->
-            <scope name="html.embedded.style" spell-check="false" lookup="documentation">
-                <starts-with>
-                    <expression>(?=&lt;(?i:style)\b)</expression>
-                </starts-with>
-                <ends-with>
+            <!-- SASS -->
+            <scope name="html.embedded.block.style" spell-check="false" lookup="documentation">
+              <starts-with>
+                <expression>(?=&lt;(?i:style)\b)(?=[^&gt;]*lang=('sass'|\"sass\"))(?![^/&gt;]*/&gt;\s*$)</expression>
+              </starts-with>
+              <ends-with />
+              <subscopes anchored="true" skip-whitespace="false">
+                <scope name="html.tag.style.open">
+                  <symbol type="tag-style">
+                    <context behavior="start" group-by-name="true">
+                      <auto-close string="&lt;/" completion="${name}&gt;" />
+                    </context>
+                  </symbol>
+                  <starts-with>
+                    <expression>&lt;((?i:style))</expression>
+                    <capture number="1" name="html.tag.name" />
+                  </starts-with>
+                  <ends-with>
+                    <expression>/?&gt;</expression>
+                  </ends-with>
+                  <subscopes>
+                    <include syntax="html" collection="attributes" />
+                  </subscopes>
+                </scope>
+                <scope name="html.embedded.block.style.content">
+                  <starts-with>
+                    <expression>(?&lt;=&gt;)</expression>
+                  </starts-with>
+                  <ends-with>
                     <expression>(?=&lt;/(?i:style)\b)</expression>
-                </ends-with>
-                <subscopes>
-                    <scope name="html.tag.style.open">
-                        <symbol type="tag-style">
-                            <context behavior="start" group-by-name="true">
-                                <auto-close string="&lt;/" completion="${name}&gt;" />
-                            </context>
-                        </symbol>
-                        <starts-with>
-                            <expression>&lt;((?i:style))</expression>
-                            <capture number="1" name="html.tag.name" />
-                        </starts-with>
-                        <ends-with>
-                            <expression>/?&gt;</expression>
-                        </ends-with>
-                        <subscopes>
-                            <include syntax="self" collection="attributes" />
-                        </subscopes>
-                    </scope>
-                    <scope name="html.embedded.style.content">
-                        <starts-with>
-                            <expression>(?&lt;=&gt;)</expression>
-                        </starts-with>
-                        <ends-with>
-                            <expression>(?=&lt;/(?i:style)\b)</expression>
-                        </ends-with>
-                        <subsyntax name="css">
-                            <cut-off>
-                                <expression>(?=&lt;/(?i:style|head|body|div)\b)</expression>
-                            </cut-off>
-                        </subsyntax>
-                    </scope>
-                </subscopes>
+                  </ends-with>
+                  <subsyntax name="sass">
+                    <cut-off>
+                      <expression>(?=&lt;/(?i:style)\b)</expression>
+                    </cut-off>
+                  </subsyntax>
+                </scope>
+              </subscopes>
+            </scope>
+            
+            <!-- SCSS -->
+            <scope name="html.embedded.block.style" spell-check="false" lookup="documentation">
+              <starts-with>
+                <expression>(?=&lt;(?i:style)\b)(?=[^&gt;]*lang=('scss'|\"scss\"))(?![^/&gt;]*/&gt;\s*$)</expression>
+              </starts-with>
+              <ends-with />
+              <subscopes anchored="true" skip-whitespace="false">
+                <scope name="html.tag.style.open">
+                  <symbol type="tag-style">
+                    <context behavior="start" group-by-name="true">
+                      <auto-close string="&lt;/" completion="${name}&gt;" />
+                    </context>
+                  </symbol>
+                  <starts-with>
+                    <expression>&lt;((?i:style))</expression>
+                    <capture number="1" name="html.tag.name" />
+                  </starts-with>
+                  <ends-with>
+                    <expression>/?&gt;</expression>
+                  </ends-with>
+                  <subscopes>
+                    <include syntax="html" collection="attributes" />
+                  </subscopes>
+                </scope>
+                <scope name="html.embedded.block.style.content">
+                  <starts-with>
+                    <expression>(?&lt;=&gt;)</expression>
+                  </starts-with>
+                  <ends-with>
+                    <expression>(?=&lt;/(?i:style)\b)</expression>
+                  </ends-with>
+                  <subsyntax name="scss">
+                    <cut-off>
+                      <expression>(?=&lt;/(?i:style)\b)</expression>
+                    </cut-off>
+                  </subsyntax>
+                </scope>
+              </subscopes>
+            </scope>
+            
+            <!-- LESS -->
+            <scope name="html.embedded.block.style" spell-check="false" lookup="documentation">
+              <starts-with>
+                <expression>(?=&lt;(?i:style)\b)(?=[^&gt;]*lang=('less'|\"less\"))(?![^/&gt;]*/&gt;\s*$)</expression>
+              </starts-with>
+              <ends-with />
+              <subscopes anchored="true" skip-whitespace="false">
+                <scope name="html.tag.style.open">
+                  <symbol type="tag-style">
+                    <context behavior="start" group-by-name="true">
+                      <auto-close string="&lt;/" completion="${name}&gt;" />
+                    </context>
+                  </symbol>
+                  <starts-with>
+                    <expression>&lt;((?i:style))</expression>
+                    <capture number="1" name="html.tag.name" />
+                  </starts-with>
+                  <ends-with>
+                    <expression>/?&gt;</expression>
+                  </ends-with>
+                  <subscopes>
+                    <include syntax="html" collection="attributes" />
+                  </subscopes>
+                </scope>
+                <scope name="html.embedded.block.style.content">
+                  <starts-with>
+                    <expression>(?&lt;=&gt;)</expression>
+                  </starts-with>
+                  <ends-with>
+                    <expression>(?=&lt;/(?i:style)\b)</expression>
+                  </ends-with>
+                  <subsyntax name="less">
+                    <cut-off>
+                      <expression>(?=&lt;/(?i:style)\b)</expression>
+                    </cut-off>
+                  </subsyntax>
+                </scope>
+              </subscopes>
+            </scope>
+            
+            <!-- CSS -->
+            <scope name="html.embedded.block.style" spell-check="false" lookup="documentation">
+              <starts-with>
+                <expression>(?=&lt;(?i:style)\b)</expression>
+              </starts-with>
+              <ends-with />
+              <subscopes anchored="true" skip-whitespace="false">
+                <scope name="html.tag.style.open">
+                  <symbol type="tag-style">
+                    <context behavior="start" group-by-name="true">
+                      <auto-close string="&lt;/" completion="${name}&gt;" />
+                    </context>
+                  </symbol>
+                  <starts-with>
+                    <expression>&lt;((?i:style))</expression>
+                    <capture number="1" name="html.tag.name" />
+                  </starts-with>
+                  <ends-with>
+                    <expression>/?&gt;</expression>
+                  </ends-with>
+                  <subscopes>
+                    <include syntax="html" collection="attributes" />
+                  </subscopes>
+                </scope>
+                <scope name="html.embedded.block.style.content">
+                  <starts-with>
+                    <expression>(?&lt;=&gt;)</expression>
+                  </starts-with>
+                  <ends-with>
+                    <expression>(?=&lt;/(?i:style)\b)</expression>
+                  </ends-with>
+                  <subsyntax name="css">
+                    <cut-off>
+                      <expression>(?=&lt;/(?i:style)\b)</expression>
+                    </cut-off>
+                  </subsyntax>
+                </scope>
+              </subscopes>
             </scope>
             
             <!-- Closing Tags -->

--- a/SvelteNova.novaextension/Syntaxes/Svelte.xml
+++ b/SvelteNova.novaextension/Syntaxes/Svelte.xml
@@ -350,50 +350,92 @@
     <collections>
         <!-- Tags -->
         <collection name="tags">
-            <!-- Script -->
-            <scope name="html.embedded.script" spell-check="false" lookup="documentation">
-                <starts-with>
-                    <expression>(?=&lt;(?i:script)\b)</expression>
-                </starts-with>
-                <ends-with>
+            <!-- Typescript -->
+            <scope name="html.embedded.block.script" spell-check="false" lookup="documentation">
+              <starts-with>
+                <expression>(?=&lt;(?i:script)\b)(?=[^&gt;]*lang=('ts'|\"ts\"))(?![^/&gt;]*/&gt;\s*$)</expression>
+              </starts-with>
+              <ends-with />
+              <subscopes anchored="true" skip-whitespace="false">
+                <scope name="html.tag.script.open">
+                  <symbol type="tag-script">
+                    <display-name>
+                      <component variable="name" />
+                      <component selector="html.tag.attribute.value.link" prepend=" – " />
+                    </display-name>
+                    <context behavior="start" group-by-name="true">
+                      <auto-close string="&lt;/" completion="${name}&gt;" />
+                    </context>
+                  </symbol>
+                  <starts-with>
+                    <expression>&lt;((?i:script))</expression>
+                    <capture number="1" name="html.tag.name" />
+                  </starts-with>
+                  <ends-with>
+                    <expression>/?&gt;</expression>
+                  </ends-with>
+                  <subscopes>
+                    <include syntax="html" collection="attributes" />
+                  </subscopes>
+                </scope>
+                <scope name="html.embedded.block.script.content">
+                  <starts-with>
+                    <expression>(?&lt;=&gt;)</expression>
+                  </starts-with>
+                  <ends-with>
                     <expression>(?=&lt;/(?i:script)\b)</expression>
-                </ends-with>
-                <subscopes>
-                    <scope name="html.tag.script.open">
-                        <symbol type="tag-script">
-                            <display-name>
-                                <component variable="name" />
-                                <component selector="html.tag.attribute.value.link" prepend=" – " />
-                            </display-name>
-                            <context behavior="start" group-by-name="true">
-                                <auto-close string="&lt;/" completion="${name}&gt;" />
-                            </context>
-                        </symbol>
-                        <starts-with>
-                            <expression>&lt;((?i:script))</expression>
-                            <capture number="1" name="html.tag.name" />
-                        </starts-with>
-                        <ends-with>
-                            <expression>/?&gt;</expression>
-                        </ends-with>
-                        <subscopes>
-                            <include syntax="self" collection="attributes" />
-                        </subscopes>
-                    </scope>
-                    <scope name="html.embedded.script.content">
-                        <starts-with>
-                            <expression>(?&lt;=&gt;)</expression>
-                        </starts-with>
-                        <ends-with>
-                            <expression>(?=&lt;/(?i:script)\b)</expression>
-                        </ends-with>
-                        <subsyntax name="javascript">
-                            <cut-off>
-                                <expression>(?=&lt;/(?i:script|head|body|div)\b)</expression>
-                            </cut-off>
-                        </subsyntax>
-                    </scope>
-                </subscopes>
+                  </ends-with>
+                  <subsyntax name="typescript">
+                    <cut-off>
+                      <expression>(?=&lt;/(?i:script)\b)</expression>
+                    </cut-off>
+                  </subsyntax>
+                </scope>
+              </subscopes>
+            </scope>
+            
+            <!-- Javascript -->
+            <scope name="html.embedded.block.script" spell-check="false" lookup="documentation">
+              <starts-with>
+                <expression>(?=&lt;(?i:script)\b)</expression>
+              </starts-with>
+              <ends-with />
+              <subscopes anchored="true" skip-whitespace="false">
+                <scope name="html.tag.script.open">
+                  <symbol type="tag-script">
+                    <display-name>
+                      <component variable="name" />
+                      <component selector="html.tag.attribute.value.link" prepend=" – " />
+                    </display-name>
+                    <context behavior="start" group-by-name="true">
+                      <auto-close string="&lt;/" completion="${name}&gt;" />
+                    </context>
+                  </symbol>
+                  <starts-with>
+                    <expression>&lt;((?i:script))</expression>
+                    <capture number="1" name="html.tag.name" />
+                  </starts-with>
+                  <ends-with>
+                    <expression>/?&gt;</expression>
+                  </ends-with>
+                  <subscopes>
+                    <include syntax="html" collection="attributes" />
+                  </subscopes>
+                </scope>
+                <scope name="html.embedded.block.script.content">
+                  <starts-with>
+                    <expression>(?&lt;=&gt;)</expression>
+                  </starts-with>
+                  <ends-with>
+                    <expression>(?=&lt;/(?i:script)\b)</expression>
+                  </ends-with>
+                  <subsyntax name="javascript">
+                    <cut-off>
+                      <expression>(?=&lt;/(?i:script)\b)</expression>
+                    </cut-off>
+                  </subsyntax>
+                </scope>
+              </subscopes>
             </scope>
             
             <!-- Style -->

--- a/SvelteNova.novaextension/package.json
+++ b/SvelteNova.novaextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sveltenova.novaextension",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "dependencies": {
     "svelte-language-server": "^0.10.147"
   }


### PR DESCRIPTION
This should be a fix for issue #1.

I looked at how it was done in the [Vue extension](https://github.com/tommasongr/nova-vue) and adapted it.